### PR TITLE
Add value objects for ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# soccer
+# Soccer API
+
+This project is a minimal demo of a soccer management API built with Spring Boot following a hexagonal architecture with a simple command and query bus.
+Domain entities now use small value objects for identifiers to better express intent.
+
+## Modules
+- **Teams**: Manage team creation and listing.
+- **Players**: Register players for teams.
+- **Scores**: Provides standings and top scorer tables.
+
+## Build and Run
+Use Maven to build and run the project:
+```bash
+mvn spring-boot:run
+```
+
+Run tests with:
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>soccer</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>soccer</name>
+    <description>Soccer Management API</description>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/soccer/SoccerApplication.java
+++ b/src/main/java/com/example/soccer/SoccerApplication.java
@@ -1,0 +1,12 @@
+package com.example.soccer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SoccerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SoccerApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/soccer/application/common/Command.java
+++ b/src/main/java/com/example/soccer/application/common/Command.java
@@ -1,0 +1,4 @@
+package com.example.soccer.application.common;
+
+public interface Command<R> {
+}

--- a/src/main/java/com/example/soccer/application/common/CommandBus.java
+++ b/src/main/java/com/example/soccer/application/common/CommandBus.java
@@ -1,0 +1,5 @@
+package com.example.soccer.application.common;
+
+public interface CommandBus {
+    <R, C extends Command<R>> R dispatch(C command);
+}

--- a/src/main/java/com/example/soccer/application/common/CommandHandler.java
+++ b/src/main/java/com/example/soccer/application/common/CommandHandler.java
@@ -1,0 +1,5 @@
+package com.example.soccer.application.common;
+
+public interface CommandHandler<C extends Command<R>, R> {
+    R handle(C command);
+}

--- a/src/main/java/com/example/soccer/application/common/Query.java
+++ b/src/main/java/com/example/soccer/application/common/Query.java
@@ -1,0 +1,4 @@
+package com.example.soccer.application.common;
+
+public interface Query<R> {
+}

--- a/src/main/java/com/example/soccer/application/common/QueryBus.java
+++ b/src/main/java/com/example/soccer/application/common/QueryBus.java
@@ -1,0 +1,5 @@
+package com.example.soccer.application.common;
+
+public interface QueryBus {
+    <R, Q extends Query<R>> R dispatch(Q query);
+}

--- a/src/main/java/com/example/soccer/application/common/QueryHandler.java
+++ b/src/main/java/com/example/soccer/application/common/QueryHandler.java
@@ -1,0 +1,5 @@
+package com.example.soccer.application.common;
+
+public interface QueryHandler<Q extends Query<R>, R> {
+    R handle(Q query);
+}

--- a/src/main/java/com/example/soccer/application/player/CreatePlayerCommand.java
+++ b/src/main/java/com/example/soccer/application/player/CreatePlayerCommand.java
@@ -1,0 +1,21 @@
+package com.example.soccer.application.player;
+
+import com.example.soccer.application.common.Command;
+import com.example.soccer.domain.player.PlayerId;
+import com.example.soccer.domain.team.TeamId;
+
+public class CreatePlayerCommand implements Command<PlayerId> {
+    private final PlayerId id;
+    private final TeamId teamId;
+    private final String name;
+
+    public CreatePlayerCommand(PlayerId id, TeamId teamId, String name) {
+        this.id = id;
+        this.teamId = teamId;
+        this.name = name;
+    }
+
+    public PlayerId getId() { return id; }
+    public TeamId getTeamId() { return teamId; }
+    public String getName() { return name; }
+}

--- a/src/main/java/com/example/soccer/application/player/CreatePlayerCommandHandler.java
+++ b/src/main/java/com/example/soccer/application/player/CreatePlayerCommandHandler.java
@@ -1,0 +1,30 @@
+package com.example.soccer.application.player;
+
+import com.example.soccer.application.common.CommandHandler;
+import com.example.soccer.domain.player.Player;
+import com.example.soccer.domain.player.PlayerCreatedEvent;
+import com.example.soccer.domain.player.PlayerId;
+import com.example.soccer.domain.player.PlayerRepository;
+import com.example.soccer.domain.team.TeamId;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreatePlayerCommandHandler implements CommandHandler<CreatePlayerCommand, PlayerId> {
+
+    private final PlayerRepository repository;
+    private final ApplicationEventPublisher events;
+
+    public CreatePlayerCommandHandler(PlayerRepository repository, ApplicationEventPublisher events) {
+        this.repository = repository;
+        this.events = events;
+    }
+
+    @Override
+    public PlayerId handle(CreatePlayerCommand command) {
+        Player player = new Player(command.getId(), command.getTeamId(), command.getName());
+        repository.save(player);
+        events.publishEvent(new PlayerCreatedEvent(player));
+        return player.getId();
+    }
+}

--- a/src/main/java/com/example/soccer/application/score/GetStandingsQuery.java
+++ b/src/main/java/com/example/soccer/application/score/GetStandingsQuery.java
@@ -1,0 +1,6 @@
+package com.example.soccer.application.score;
+
+import com.example.soccer.application.common.Query;
+
+public class GetStandingsQuery implements Query<java.util.List<com.example.soccer.domain.score.Standing>> {
+}

--- a/src/main/java/com/example/soccer/application/score/GetStandingsQueryHandler.java
+++ b/src/main/java/com/example/soccer/application/score/GetStandingsQueryHandler.java
@@ -1,0 +1,23 @@
+package com.example.soccer.application.score;
+
+import com.example.soccer.application.common.QueryHandler;
+import com.example.soccer.domain.score.Standing;
+import com.example.soccer.domain.score.StandingRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetStandingsQueryHandler implements QueryHandler<GetStandingsQuery, List<Standing>> {
+
+    private final StandingRepository repository;
+
+    public GetStandingsQueryHandler(StandingRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<Standing> handle(GetStandingsQuery query) {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/example/soccer/application/score/GetTopScorersQuery.java
+++ b/src/main/java/com/example/soccer/application/score/GetTopScorersQuery.java
@@ -1,0 +1,6 @@
+package com.example.soccer.application.score;
+
+import com.example.soccer.application.common.Query;
+
+public class GetTopScorersQuery implements Query<java.util.List<com.example.soccer.domain.score.ScoreEntry>> {
+}

--- a/src/main/java/com/example/soccer/application/score/GetTopScorersQueryHandler.java
+++ b/src/main/java/com/example/soccer/application/score/GetTopScorersQueryHandler.java
@@ -1,0 +1,23 @@
+package com.example.soccer.application.score;
+
+import com.example.soccer.application.common.QueryHandler;
+import com.example.soccer.domain.score.ScoreEntry;
+import com.example.soccer.domain.score.ScoreRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetTopScorersQueryHandler implements QueryHandler<GetTopScorersQuery, List<ScoreEntry>> {
+
+    private final ScoreRepository repository;
+
+    public GetTopScorersQueryHandler(ScoreRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<ScoreEntry> handle(GetTopScorersQuery query) {
+        return repository.findTopScorers();
+    }
+}

--- a/src/main/java/com/example/soccer/application/team/CreateTeamCommand.java
+++ b/src/main/java/com/example/soccer/application/team/CreateTeamCommand.java
@@ -1,0 +1,22 @@
+package com.example.soccer.application.team;
+
+import com.example.soccer.application.common.Command;
+import com.example.soccer.domain.team.TeamId;
+
+public class CreateTeamCommand implements Command<TeamId> {
+    private final TeamId id;
+    private final String name;
+
+    public CreateTeamCommand(TeamId id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public TeamId getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/soccer/application/team/CreateTeamCommandHandler.java
+++ b/src/main/java/com/example/soccer/application/team/CreateTeamCommandHandler.java
@@ -1,0 +1,29 @@
+package com.example.soccer.application.team;
+
+import com.example.soccer.application.common.CommandHandler;
+import com.example.soccer.domain.team.Team;
+import com.example.soccer.domain.team.TeamCreatedEvent;
+import com.example.soccer.domain.team.TeamId;
+import com.example.soccer.domain.team.TeamRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreateTeamCommandHandler implements CommandHandler<CreateTeamCommand, TeamId> {
+
+    private final TeamRepository repository;
+    private final ApplicationEventPublisher events;
+
+    public CreateTeamCommandHandler(TeamRepository repository, ApplicationEventPublisher events) {
+        this.repository = repository;
+        this.events = events;
+    }
+
+    @Override
+    public TeamId handle(CreateTeamCommand command) {
+        Team team = new Team(command.getId(), command.getName());
+        repository.save(team);
+        events.publishEvent(new TeamCreatedEvent(team));
+        return team.getId();
+    }
+}

--- a/src/main/java/com/example/soccer/application/team/GetAllTeamsQuery.java
+++ b/src/main/java/com/example/soccer/application/team/GetAllTeamsQuery.java
@@ -1,0 +1,6 @@
+package com.example.soccer.application.team;
+
+import com.example.soccer.application.common.Query;
+
+public class GetAllTeamsQuery implements Query<java.util.List<String>> {
+}

--- a/src/main/java/com/example/soccer/application/team/GetAllTeamsQueryHandler.java
+++ b/src/main/java/com/example/soccer/application/team/GetAllTeamsQueryHandler.java
@@ -1,0 +1,24 @@
+package com.example.soccer.application.team;
+
+import com.example.soccer.application.common.QueryHandler;
+import com.example.soccer.domain.team.Team;
+import com.example.soccer.domain.team.TeamRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class GetAllTeamsQueryHandler implements QueryHandler<GetAllTeamsQuery, List<String>> {
+
+    private final TeamRepository repository;
+
+    public GetAllTeamsQueryHandler(TeamRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<String> handle(GetAllTeamsQuery query) {
+        return repository.findAll().stream().map(Team::getName).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/soccer/domain/match/Match.java
+++ b/src/main/java/com/example/soccer/domain/match/Match.java
@@ -1,0 +1,26 @@
+package com.example.soccer.domain.match;
+
+import com.example.soccer.domain.team.TeamId;
+import java.time.LocalDate;
+
+/**
+ * Aggregate root representing a scheduled match.
+ */
+public class Match {
+    private final MatchId id;
+    private final TeamId homeTeam;
+    private final TeamId awayTeam;
+    private final LocalDate date;
+
+    public Match(MatchId id, TeamId homeTeam, TeamId awayTeam, LocalDate date) {
+        this.id = id;
+        this.homeTeam = homeTeam;
+        this.awayTeam = awayTeam;
+        this.date = date;
+    }
+
+    public MatchId getId() { return id; }
+    public TeamId getHomeTeam() { return homeTeam; }
+    public TeamId getAwayTeam() { return awayTeam; }
+    public LocalDate getDate() { return date; }
+}

--- a/src/main/java/com/example/soccer/domain/match/MatchId.java
+++ b/src/main/java/com/example/soccer/domain/match/MatchId.java
@@ -1,0 +1,14 @@
+package com.example.soccer.domain.match;
+
+import java.util.Objects;
+
+public record MatchId(String value) {
+    public MatchId {
+        Objects.requireNonNull(value, "id must not be null");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/match/MatchRepository.java
+++ b/src/main/java/com/example/soccer/domain/match/MatchRepository.java
@@ -1,0 +1,10 @@
+package com.example.soccer.domain.match;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MatchRepository {
+    Optional<Match> findById(MatchId id);
+    List<Match> findAll();
+    void save(Match match);
+}

--- a/src/main/java/com/example/soccer/domain/player/Player.java
+++ b/src/main/java/com/example/soccer/domain/player/Player.java
@@ -1,0 +1,22 @@
+package com.example.soccer.domain.player;
+
+import com.example.soccer.domain.team.TeamId;
+
+/**
+ * Aggregate root representing a player.
+ */
+public class Player {
+    private final PlayerId id;
+    private final TeamId teamId;
+    private final String name;
+
+    public Player(PlayerId id, TeamId teamId, String name) {
+        this.id = id;
+        this.teamId = teamId;
+        this.name = name;
+    }
+
+    public PlayerId getId() { return id; }
+    public TeamId getTeamId() { return teamId; }
+    public String getName() { return name; }
+}

--- a/src/main/java/com/example/soccer/domain/player/PlayerCreatedEvent.java
+++ b/src/main/java/com/example/soccer/domain/player/PlayerCreatedEvent.java
@@ -1,0 +1,13 @@
+package com.example.soccer.domain.player;
+
+public class PlayerCreatedEvent {
+    private final Player player;
+
+    public PlayerCreatedEvent(Player player) {
+        this.player = player;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/player/PlayerId.java
+++ b/src/main/java/com/example/soccer/domain/player/PlayerId.java
@@ -1,0 +1,14 @@
+package com.example.soccer.domain.player;
+
+import java.util.Objects;
+
+public record PlayerId(String value) {
+    public PlayerId {
+        Objects.requireNonNull(value, "id must not be null");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/player/PlayerRepository.java
+++ b/src/main/java/com/example/soccer/domain/player/PlayerRepository.java
@@ -1,0 +1,11 @@
+package com.example.soccer.domain.player;
+
+import com.example.soccer.domain.team.TeamId;
+import java.util.List;
+import java.util.Optional;
+
+public interface PlayerRepository {
+    Optional<Player> findById(PlayerId id);
+    List<Player> findByTeam(TeamId teamId);
+    void save(Player player);
+}

--- a/src/main/java/com/example/soccer/domain/score/ScoreEntry.java
+++ b/src/main/java/com/example/soccer/domain/score/ScoreEntry.java
@@ -1,0 +1,19 @@
+package com.example.soccer.domain.score;
+
+import com.example.soccer.domain.player.PlayerId;
+
+/**
+ * Value object representing a player's goal tally.
+ */
+public class ScoreEntry {
+    private final PlayerId playerId;
+    private final int goals;
+
+    public ScoreEntry(PlayerId playerId, int goals) {
+        this.playerId = playerId;
+        this.goals = goals;
+    }
+
+    public PlayerId getPlayerId() { return playerId; }
+    public int getGoals() { return goals; }
+}

--- a/src/main/java/com/example/soccer/domain/score/ScoreRepository.java
+++ b/src/main/java/com/example/soccer/domain/score/ScoreRepository.java
@@ -1,0 +1,8 @@
+package com.example.soccer.domain.score;
+
+import java.util.List;
+
+public interface ScoreRepository {
+    List<ScoreEntry> findTopScorers();
+    void save(ScoreEntry entry);
+}

--- a/src/main/java/com/example/soccer/domain/score/Standing.java
+++ b/src/main/java/com/example/soccer/domain/score/Standing.java
@@ -1,0 +1,19 @@
+package com.example.soccer.domain.score;
+
+import com.example.soccer.domain.team.TeamId;
+
+/**
+ * Value object representing team points in standings.
+ */
+public class Standing {
+    private final TeamId teamId;
+    private final int points;
+
+    public Standing(TeamId teamId, int points) {
+        this.teamId = teamId;
+        this.points = points;
+    }
+
+    public TeamId getTeamId() { return teamId; }
+    public int getPoints() { return points; }
+}

--- a/src/main/java/com/example/soccer/domain/score/StandingRepository.java
+++ b/src/main/java/com/example/soccer/domain/score/StandingRepository.java
@@ -1,0 +1,8 @@
+package com.example.soccer.domain.score;
+
+import java.util.List;
+
+public interface StandingRepository {
+    List<Standing> findAll();
+    void save(Standing standing);
+}

--- a/src/main/java/com/example/soccer/domain/team/Team.java
+++ b/src/main/java/com/example/soccer/domain/team/Team.java
@@ -1,0 +1,22 @@
+package com.example.soccer.domain.team;
+
+/**
+ * Aggregate root representing a team.
+ */
+public class Team {
+    private final TeamId id;
+    private final String name;
+
+    public Team(TeamId id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public TeamId getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/team/TeamCreatedEvent.java
+++ b/src/main/java/com/example/soccer/domain/team/TeamCreatedEvent.java
@@ -1,0 +1,13 @@
+package com.example.soccer.domain.team;
+
+public class TeamCreatedEvent {
+    private final Team team;
+
+    public TeamCreatedEvent(Team team) {
+        this.team = team;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/team/TeamId.java
+++ b/src/main/java/com/example/soccer/domain/team/TeamId.java
@@ -1,0 +1,14 @@
+package com.example.soccer.domain.team;
+
+import java.util.Objects;
+
+public record TeamId(String value) {
+    public TeamId {
+        Objects.requireNonNull(value, "id must not be null");
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/com/example/soccer/domain/team/TeamRepository.java
+++ b/src/main/java/com/example/soccer/domain/team/TeamRepository.java
@@ -1,0 +1,10 @@
+package com.example.soccer.domain.team;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamRepository {
+    Optional<Team> findById(TeamId id);
+    List<Team> findAll();
+    void save(Team team);
+}

--- a/src/main/java/com/example/soccer/infrastructure/common/SimpleCommandBus.java
+++ b/src/main/java/com/example/soccer/infrastructure/common/SimpleCommandBus.java
@@ -1,0 +1,23 @@
+package com.example.soccer.infrastructure.common;
+
+import com.example.soccer.application.common.Command;
+import com.example.soccer.application.common.CommandBus;
+import com.example.soccer.application.common.CommandHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SimpleCommandBus implements CommandBus {
+
+    private final ApplicationContext context;
+
+    public SimpleCommandBus(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public <R, C extends Command<R>> R dispatch(C command) {
+        CommandHandler<C, R> handler = (CommandHandler<C, R>) context.getBean(command.getClass().getSimpleName() + "Handler");
+        return handler.handle(command);
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/common/SimpleQueryBus.java
+++ b/src/main/java/com/example/soccer/infrastructure/common/SimpleQueryBus.java
@@ -1,0 +1,23 @@
+package com.example.soccer.infrastructure.common;
+
+import com.example.soccer.application.common.Query;
+import com.example.soccer.application.common.QueryBus;
+import com.example.soccer.application.common.QueryHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SimpleQueryBus implements QueryBus {
+
+    private final ApplicationContext context;
+
+    public SimpleQueryBus(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public <R, Q extends Query<R>> R dispatch(Q query) {
+        QueryHandler<Q, R> handler = (QueryHandler<Q, R>) context.getBean(query.getClass().getSimpleName() + "Handler");
+        return handler.handle(query);
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/player/InMemoryPlayerRepository.java
+++ b/src/main/java/com/example/soccer/infrastructure/player/InMemoryPlayerRepository.java
@@ -1,0 +1,36 @@
+package com.example.soccer.infrastructure.player;
+
+import com.example.soccer.domain.player.Player;
+import com.example.soccer.domain.player.PlayerId;
+import com.example.soccer.domain.player.PlayerRepository;
+import com.example.soccer.domain.team.TeamId;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class InMemoryPlayerRepository implements PlayerRepository {
+
+    private final Map<PlayerId, Player> players = new HashMap<>();
+
+    @Override
+    public Optional<Player> findById(PlayerId id) {
+        return Optional.ofNullable(players.get(id));
+    }
+
+    @Override
+    public List<Player> findByTeam(TeamId teamId) {
+        List<Player> result = new ArrayList<>();
+        for (Player p : players.values()) {
+            if (p.getTeamId().equals(teamId)) {
+                result.add(p);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void save(Player player) {
+        players.put(player.getId(), player);
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/player/PlayerController.java
+++ b/src/main/java/com/example/soccer/infrastructure/player/PlayerController.java
@@ -1,0 +1,31 @@
+package com.example.soccer.infrastructure.player;
+
+import com.example.soccer.application.common.CommandBus;
+import com.example.soccer.application.player.CreatePlayerCommand;
+import com.example.soccer.domain.player.PlayerId;
+import com.example.soccer.domain.team.TeamId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/players")
+public class PlayerController {
+
+    private final CommandBus commandBus;
+
+    public PlayerController(CommandBus commandBus) {
+        this.commandBus = commandBus;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody CreatePlayerRequest request) {
+        PlayerId id = commandBus.dispatch(
+                new CreatePlayerCommand(
+                        new PlayerId(request.id()),
+                        new TeamId(request.teamId()),
+                        request.name()));
+        return ResponseEntity.ok(id.toString());
+    }
+
+    public record CreatePlayerRequest(String id, String teamId, String name) {}
+}

--- a/src/main/java/com/example/soccer/infrastructure/score/InMemoryScoreRepository.java
+++ b/src/main/java/com/example/soccer/infrastructure/score/InMemoryScoreRepository.java
@@ -1,0 +1,29 @@
+package com.example.soccer.infrastructure.score;
+
+import com.example.soccer.domain.player.PlayerId;
+import com.example.soccer.domain.score.ScoreEntry;
+import com.example.soccer.domain.score.ScoreRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class InMemoryScoreRepository implements ScoreRepository {
+
+    private final Map<PlayerId, Integer> scores = new HashMap<>();
+
+    @Override
+    public List<ScoreEntry> findTopScorers() {
+        List<ScoreEntry> entries = new ArrayList<>();
+        for (Map.Entry<PlayerId, Integer> e : scores.entrySet()) {
+            entries.add(new ScoreEntry(e.getKey(), e.getValue()));
+        }
+        entries.sort((a, b) -> Integer.compare(b.getGoals(), a.getGoals()));
+        return entries;
+    }
+
+    @Override
+    public void save(ScoreEntry entry) {
+        scores.put(entry.getPlayerId(), entry.getGoals());
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/score/InMemoryStandingRepository.java
+++ b/src/main/java/com/example/soccer/infrastructure/score/InMemoryStandingRepository.java
@@ -1,0 +1,29 @@
+package com.example.soccer.infrastructure.score;
+
+import com.example.soccer.domain.score.Standing;
+import com.example.soccer.domain.score.StandingRepository;
+import com.example.soccer.domain.team.TeamId;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class InMemoryStandingRepository implements StandingRepository {
+
+    private final Map<TeamId, Integer> standings = new HashMap<>();
+
+    @Override
+    public List<Standing> findAll() {
+        List<Standing> list = new ArrayList<>();
+        for (Map.Entry<TeamId, Integer> e : standings.entrySet()) {
+            list.add(new Standing(e.getKey(), e.getValue()));
+        }
+        list.sort((a,b) -> Integer.compare(b.getPoints(), a.getPoints()));
+        return list;
+    }
+
+    @Override
+    public void save(Standing standing) {
+        standings.put(standing.getTeamId(), standing.getPoints());
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/score/ScoreController.java
+++ b/src/main/java/com/example/soccer/infrastructure/score/ScoreController.java
@@ -1,0 +1,34 @@
+package com.example.soccer.infrastructure.score;
+
+import com.example.soccer.application.common.QueryBus;
+import com.example.soccer.application.score.GetStandingsQuery;
+import com.example.soccer.application.score.GetTopScorersQuery;
+import com.example.soccer.domain.score.ScoreEntry;
+import com.example.soccer.domain.score.Standing;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/scores")
+public class ScoreController {
+
+    private final QueryBus queryBus;
+
+    public ScoreController(QueryBus queryBus) {
+        this.queryBus = queryBus;
+    }
+
+    @GetMapping("/standings")
+    public ResponseEntity<List<Standing>> standings() {
+        return ResponseEntity.ok(queryBus.dispatch(new GetStandingsQuery()));
+    }
+
+    @GetMapping("/top-scorers")
+    public ResponseEntity<List<ScoreEntry>> topScorers() {
+        return ResponseEntity.ok(queryBus.dispatch(new GetTopScorersQuery()));
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/team/InMemoryTeamRepository.java
+++ b/src/main/java/com/example/soccer/infrastructure/team/InMemoryTeamRepository.java
@@ -1,0 +1,29 @@
+package com.example.soccer.infrastructure.team;
+
+import com.example.soccer.domain.team.Team;
+import com.example.soccer.domain.team.TeamId;
+import com.example.soccer.domain.team.TeamRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class InMemoryTeamRepository implements TeamRepository {
+
+    private final Map<TeamId, Team> teams = new HashMap<>();
+
+    @Override
+    public Optional<Team> findById(TeamId id) {
+        return Optional.ofNullable(teams.get(id));
+    }
+
+    @Override
+    public List<Team> findAll() {
+        return new ArrayList<>(teams.values());
+    }
+
+    @Override
+    public void save(Team team) {
+        teams.put(team.getId(), team);
+    }
+}

--- a/src/main/java/com/example/soccer/infrastructure/team/TeamController.java
+++ b/src/main/java/com/example/soccer/infrastructure/team/TeamController.java
@@ -1,0 +1,37 @@
+package com.example.soccer.infrastructure.team;
+
+import com.example.soccer.application.common.CommandBus;
+import com.example.soccer.application.common.QueryBus;
+import com.example.soccer.application.team.CreateTeamCommand;
+import com.example.soccer.application.team.GetAllTeamsQuery;
+import com.example.soccer.domain.team.TeamId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/teams")
+public class TeamController {
+
+    private final CommandBus commandBus;
+    private final QueryBus queryBus;
+
+    public TeamController(CommandBus commandBus, QueryBus queryBus) {
+        this.commandBus = commandBus;
+        this.queryBus = queryBus;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody CreateTeamRequest request) {
+        TeamId id = commandBus.dispatch(new CreateTeamCommand(new TeamId(request.id()), request.name()));
+        return ResponseEntity.ok(id.toString());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<String>> all() {
+        return ResponseEntity.ok(queryBus.dispatch(new GetAllTeamsQuery()));
+    }
+
+    public record CreateTeamRequest(String id, String name) {}
+}

--- a/src/test/java/com/example/soccer/SoccerApplicationTests.java
+++ b/src/test/java/com/example/soccer/SoccerApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.soccer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SoccerApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add `TeamId`, `PlayerId` and `MatchId` value objects
- refactor domain entities and repositories to use them
- update command handlers and controllers accordingly
- mention value objects in README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867214edad88320b5cbef379deb5b01