### PR TITLE
Fix infrastructure package naming

### DIFF
--- a/src/main/java/com/example/soccer/score/infrastructure/InMemoryScoreRepository.java
+++ b/src/main/java/com/example/soccer/score/infrastructure/InMemoryScoreRepository.java
@@ -1,4 +1,4 @@
-package com.example.soccer.score.infraestructure;
+package com.example.soccer.score.infrastructure;
 
 import com.example.soccer.player.domain.PlayerId;
 import com.example.soccer.score.domain.ScoreEntry;

--- a/src/main/java/com/example/soccer/score/infrastructure/InMemoryStandingRepository.java
+++ b/src/main/java/com/example/soccer/score/infrastructure/InMemoryStandingRepository.java
@@ -1,4 +1,4 @@
-package com.example.soccer.score.infraestructure;
+package com.example.soccer.score.infrastructure;
 
 import com.example.soccer.score.domain.Standing;
 import com.example.soccer.score.domain.StandingRepository;

--- a/src/main/java/com/example/soccer/score/infrastructure/ScoreController.java
+++ b/src/main/java/com/example/soccer/score/infrastructure/ScoreController.java
@@ -1,4 +1,4 @@
-package com.example.soccer.score.infraestructure;
+package com.example.soccer.score.infrastructure;
 
 import com.example.soccer.score.application.GetStandingsQuery;
 import com.example.soccer.score.application.GetTopScorersQuery;

--- a/src/main/java/com/example/soccer/shared/infrastructure/SimpleCommandBus.java
+++ b/src/main/java/com/example/soccer/shared/infrastructure/SimpleCommandBus.java
@@ -1,4 +1,4 @@
-package com.example.soccer.shared.infraestructure;
+package com.example.soccer.shared.infrastructure;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/soccer/shared/infrastructure/SimpleQueryBus.java
+++ b/src/main/java/com/example/soccer/shared/infrastructure/SimpleQueryBus.java
@@ -1,4 +1,4 @@
-package com.example.soccer.shared.infraestructure;
+package com.example.soccer.shared.infrastructure;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/soccer/team/infrastructure/InMemoryTeamRepository.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/InMemoryTeamRepository.java
@@ -1,4 +1,4 @@
-package com.example.soccer.team.infraestructure;
+package com.example.soccer.team.infrastructure;
 
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/example/soccer/team/infrastructure/TeamController.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/TeamController.java
@@ -1,4 +1,4 @@
-package com.example.soccer.team.infraestructure;
+package com.example.soccer.team.infrastructure;
 
 import com.example.soccer.shared.application.CommandBus;
 import com.example.soccer.shared.application.QueryBus;


### PR DESCRIPTION
## Summary
- rename all `infraestructure` directories to `infrastructure`
- adjust package declarations for the renamed paths

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703c2c0748832087b2c01f8cc3ab00