### PR TITLE
Add JPA/H2 persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ target/
 .gradle/
 build/
 .env
-main
+/main

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Run tests with:
 ```
 
 The project includes Gradle wrapper scripts, so no local installation is
-required.
+required. An in-memory H2 database is configured by default and can be
+inspected at `/h2-console`. API documentation generated via Swagger is
+available at `/swagger-ui.html` when the application is running.
 
 ## Environment
 Create a `.env` file in the project root to supply environment variables when

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/example/soccer/player/infrastructure/InMemoryPlayerRepository.java
+++ b/src/main/java/com/example/soccer/player/infrastructure/InMemoryPlayerRepository.java
@@ -5,11 +5,13 @@ import com.example.soccer.player.domain.PlayerId;
 import com.example.soccer.player.domain.PlayerRepository;
 import com.example.soccer.team.domain.TeamId;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
 
 @Repository
+@Profile("inmemory")
 public class InMemoryPlayerRepository implements PlayerRepository {
 
     private final Map<PlayerId, Player> players = new HashMap<>();

--- a/src/main/java/com/example/soccer/player/infrastructure/JpaPlayerRepository.java
+++ b/src/main/java/com/example/soccer/player/infrastructure/JpaPlayerRepository.java
@@ -1,0 +1,44 @@
+package com.example.soccer.player.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.soccer.player.domain.Player;
+import com.example.soccer.player.domain.PlayerId;
+import com.example.soccer.player.domain.PlayerRepository;
+import com.example.soccer.team.domain.TeamId;
+
+@Repository
+public class JpaPlayerRepository implements PlayerRepository {
+
+    private final PlayerJpaRepository jpaRepository;
+
+    public JpaPlayerRepository(PlayerJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<Player> findById(PlayerId id) {
+        return jpaRepository.findById(id.toString())
+                .map(e -> new Player(new PlayerId(e.getId()), new TeamId(e.getTeamId()), e.getName()));
+    }
+
+    @Override
+    public List<Player> findByTeam(TeamId teamId) {
+        return jpaRepository.findAll().stream()
+                .filter(e -> e.getTeamId().equals(teamId.toString()))
+                .map(e -> new Player(new PlayerId(e.getId()), new TeamId(e.getTeamId()), e.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void save(Player player) {
+        jpaRepository.save(new PlayerEntity(
+                player.getId().toString(),
+                player.getTeamId().toString(),
+                player.getName()));
+    }
+}

--- a/src/main/java/com/example/soccer/player/infrastructure/PlayerEntity.java
+++ b/src/main/java/com/example/soccer/player/infrastructure/PlayerEntity.java
@@ -1,0 +1,35 @@
+package com.example.soccer.player.infrastructure;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "players")
+public class PlayerEntity {
+    @Id
+    private String id;
+    private String teamId;
+    private String name;
+
+    protected PlayerEntity() {
+    }
+
+    public PlayerEntity(String id, String teamId, String name) {
+        this.id = id;
+        this.teamId = teamId;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTeamId() {
+        return teamId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/soccer/player/infrastructure/PlayerJpaRepository.java
+++ b/src/main/java/com/example/soccer/player/infrastructure/PlayerJpaRepository.java
@@ -1,0 +1,6 @@
+package com.example.soccer.player.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerJpaRepository extends JpaRepository<PlayerEntity, String> {
+}

--- a/src/main/java/com/example/soccer/team/infrastructure/InMemoryTeamRepository.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/InMemoryTeamRepository.java
@@ -1,5 +1,6 @@
 package com.example.soccer.team.infrastructure;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,7 @@ import com.example.soccer.team.domain.TeamRepository;
 import java.util.*;
 
 @Component
+@Profile("inmemory")
 public class InMemoryTeamRepository implements TeamRepository {
 
     private final Map<TeamId, Team> teams = new HashMap<>();

--- a/src/main/java/com/example/soccer/team/infrastructure/JpaTeamRepository.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/JpaTeamRepository.java
@@ -1,0 +1,39 @@
+package com.example.soccer.team.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.soccer.team.domain.Team;
+import com.example.soccer.team.domain.TeamId;
+import com.example.soccer.team.domain.TeamRepository;
+
+@Repository
+public class JpaTeamRepository implements TeamRepository {
+
+    private final TeamJpaRepository jpaRepository;
+
+    public JpaTeamRepository(TeamJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<Team> findById(TeamId id) {
+        return jpaRepository.findById(id.toString())
+                .map(e -> new Team(new TeamId(e.getId()), e.getName()));
+    }
+
+    @Override
+    public List<Team> findAll() {
+        return jpaRepository.findAll().stream()
+                .map(e -> new Team(new TeamId(e.getId()), e.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void save(Team team) {
+        jpaRepository.save(new TeamEntity(team.getId().toString(), team.getName()));
+    }
+}

--- a/src/main/java/com/example/soccer/team/infrastructure/TeamEntity.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/TeamEntity.java
@@ -1,0 +1,29 @@
+package com.example.soccer.team.infrastructure;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "teams")
+public class TeamEntity {
+    @Id
+    private String id;
+    private String name;
+
+    protected TeamEntity() {
+    }
+
+    public TeamEntity(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/soccer/team/infrastructure/TeamJpaRepository.java
+++ b/src/main/java/com/example/soccer/team/infrastructure/TeamJpaRepository.java
@@ -1,0 +1,6 @@
+package com.example.soccer.team.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamJpaRepository extends JpaRepository<TeamEntity, String> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- add JPA and H2 dependencies
- create JPA entities and repositories for teams and players
- keep in-memory repositories behind the `inmemory` profile
- configure H2 database and mention Swagger and H2 console in README
- fix `.gitignore` so `src/main` files are tracked

## Testing
- `gradle test` *(fails: could not resolve Spring Boot plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687044f173708320b6fb37063ec12a25