### PR TITLE
Add goleadores endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Domain entities now use small value objects for identifiers to better express in
 - **Teams**: Manage team creation and listing.
 - **Players**: Register players for teams.
 - **Scores**: Provides standings and top scorer tables.
+  Access top scorers via `/scores/top-scorers` or its Spanish alias `/scores/goleadores`.
 
 ## Build and Run
 Use Gradle to build and run the project:

--- a/src/main/java/com/example/soccer/score/infrastructure/ScoreController.java
+++ b/src/main/java/com/example/soccer/score/infrastructure/ScoreController.java
@@ -32,4 +32,12 @@ public class ScoreController {
     public ResponseEntity<List<ScoreEntry>> topScorers() {
         return ResponseEntity.ok(queryBus.dispatch(new GetTopScorersQuery()));
     }
+
+    /**
+     * Spanish alias for {@link #topScorers()} to list goal leaders.
+     */
+    @GetMapping("/goleadores")
+    public ResponseEntity<List<ScoreEntry>> goleadores() {
+        return topScorers();
+    }
 }


### PR DESCRIPTION
## Summary
- add `/scores/goleadores` endpoint as a Spanish alias of `/scores/top-scorers`
- document the new endpoint in the README

## Testing
- `gradle test` *(fails: Plugin org.springframework.boot not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883961a2bcc8320ad0b088fa7fc6a1f